### PR TITLE
chore: fix wrong namespaces for community toolkit

### DIFF
--- a/DailyReflection.Presentation/Messages/NotificationPermissionRequestMessage.cs
+++ b/DailyReflection.Presentation/Messages/NotificationPermissionRequestMessage.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Toolkit.Mvvm.Messaging.Messages;
+﻿using CommunityToolkit.Mvvm.Messaging.Messages;
 
 namespace DailyReflection.Presentation.Messages;
 

--- a/DailyReflection.Presentation/Messages/SoberDateChangedMessage.cs
+++ b/DailyReflection.Presentation/Messages/SoberDateChangedMessage.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Toolkit.Mvvm.Messaging.Messages;
+﻿using CommunityToolkit.Mvvm.Messaging.Messages;
 using System;
 
 namespace DailyReflection.Presentation.Messages;

--- a/DailyReflection.Presentation/Messages/SoberTimeDisplayPreferenceChangedMessage.cs
+++ b/DailyReflection.Presentation/Messages/SoberTimeDisplayPreferenceChangedMessage.cs
@@ -1,5 +1,5 @@
-﻿using DailyReflection.Data.Models;
-using Microsoft.Toolkit.Mvvm.Messaging.Messages;
+﻿using CommunityToolkit.Mvvm.Messaging.Messages;
+using DailyReflection.Data.Models;
 
 namespace DailyReflection.Presentation.Messages;
 

--- a/DailyReflection/Views/SettingsView.xaml.cs
+++ b/DailyReflection/Views/SettingsView.xaml.cs
@@ -1,7 +1,6 @@
-﻿using DailyReflection.Presentation.Messages;
+﻿using CommunityToolkit.Mvvm.Messaging;
+using DailyReflection.Presentation.Messages;
 using DailyReflection.Presentation.ViewModels;
-using Microsoft.Toolkit.Mvvm.Messaging;
-
 
 
 


### PR DESCRIPTION
This pull request updates references to the MVVM Toolkit library across several files to use the newer `CommunityToolkit.Mvvm` namespace instead of the deprecated `Microsoft.Toolkit.Mvvm` namespace. This change helps ensure ongoing compatibility and support for future updates.

**Library namespace migration:**

* Updated all message classes (`NotificationPermissionRequestMessage.cs`, `SoberDateChangedMessage.cs`, `SoberTimeDisplayPreferenceChangedMessage.cs`) to use `CommunityToolkit.Mvvm.Messaging.Messages` instead of `Microsoft.Toolkit.Mvvm.Messaging.Messages`. [[1]](diffhunk://#diff-692a7488142a787776616bb3be5eb6524a22ca7aa28555ef5fe255e41f3757f9L1-R1) [[2]](diffhunk://#diff-f834661e03a07417e13a632677ceac42b7228e3a61c3af5a4f3cbf5810ab9363L1-R1) [[3]](diffhunk://#diff-33aa8740b68cfd5fccb26199d9422d4909b84dba11a114d755f8d7eb2568d595L1-R2)
* Changed the `SettingsView.xaml.cs` file to reference `CommunityToolkit.Mvvm.Messaging` instead of `Microsoft.Toolkit.Mvvm.Messaging`.