### PR TITLE
chore: move to maui font builder

### DIFF
--- a/DailyReflection/App.xaml
+++ b/DailyReflection/App.xaml
@@ -11,29 +11,13 @@
 				<ResourceDictionary Source="Resources/Styles/Styles.xaml" />
 			</ResourceDictionary.MergedDictionaries>
 
-
-			<OnPlatform x:Key="FaSolidFont" x:TypeArguments="x:String">
-				<On Platform="iOS" Value="FontAwesome5Free-Solid" />
-				<On Platform="Android" Value="FontAwesomeSolid.otf#Regular" />
-			</OnPlatform>
-
-			<OnPlatform x:Key="FaRegularFont" x:TypeArguments="x:String">
-				<On Platform="iOS" Value="FontAwesome5Free-Regular" />
-				<On Platform="Android" Value="FontAwesomeRegular.otf#Regular" />
-			</OnPlatform>
-
-			<OnPlatform x:Key="FaBrandsFont" x:TypeArguments="x:String">
-				<On Platform="iOS" Value="FontAwesome5Brands-Regular" />
-				<On Platform="Android" Value="FontAwesomeBrands.otf#Regular" />
-			</OnPlatform>
-
 			<x:String x:Key="Calendar">&#xf073;</x:String>
 
-			<FontImage x:Key="ReflectionIcon" FontFamily="{StaticResource FaSolidFont}" Glyph="&#xf02d;" Size="22" />
-			<FontImage x:Key="SettingsIcon" FontFamily="{StaticResource FaSolidFont}" Glyph="&#xf013;" Size="22" />
-			<FontImage x:Key="ShareIcon" FontFamily="{StaticResource FaSolidFont}" Glyph="&#xf14d;" Size="22" />
-			<FontImage x:Key="ClockIcon" FontFamily="{StaticResource FaRegularFont}" Glyph="&#xf017;" Size="22" />
-			<FontImage x:Key="CalendarIcon" FontFamily="{StaticResource FaRegularFont}" Glyph="{StaticResource Calendar}" Size="22" />
+			<FontImage x:Key="ReflectionIcon" FontFamily="FaSolidFont" Glyph="&#xf02d;" Size="22" />
+			<FontImage x:Key="SettingsIcon" FontFamily="FaSolidFont" Glyph="&#xf013;" Size="22" />
+			<FontImage x:Key="ShareIcon" FontFamily="FaSolidFont" Glyph="&#xf14d;" Size="22" />
+			<FontImage x:Key="ClockIcon" FontFamily="FaRegularFont" Glyph="&#xf017;" Size="22" />
+			<FontImage x:Key="CalendarIcon" FontFamily="FaRegularFont" Glyph="{StaticResource Calendar}" Size="22" />
 
 			<converters:InverseBoolConverter x:Key="InverseBoolConverter" />
 			<converters:HasValueConverter x:Key="HasValueConverter" />

--- a/DailyReflection/MauiProgram.cs
+++ b/DailyReflection/MauiProgram.cs
@@ -30,6 +30,9 @@ public static class MauiProgram
 			{
 				fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
 				fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
+				fonts.AddFont("FontAwesomeBrands.otf", "FaBrandsFont");
+				fonts.AddFont("FontAwesomeRegular.otf", "FaRegularFont");
+				fonts.AddFont("FontAwesomeSolid.otf", "FaSolidFont");
 			});
 
 		builder.Configuration.AddConfiguration(config);

--- a/DailyReflection/Views/SobrietyTimeView.xaml
+++ b/DailyReflection/Views/SobrietyTimeView.xaml
@@ -29,7 +29,7 @@
 			<Grid Grid.Row="1"
 				  IsVisible="{Binding SoberDate, Converter={StaticResource NullToBoolConverter}}"
 				  RowDefinitions="Auto, Auto">
-				<Label FontFamily="{StaticResource FaRegularFont}"
+				<Label FontFamily="FaRegularFont"
 					   FontSize="Title"
 					   HorizontalOptions="Center"
 					   Text="{StaticResource Calendar}" />


### PR DESCRIPTION
This pull request updates the way FontAwesome fonts are referenced and registered in the application, simplifying font usage and improving consistency. The main changes are the removal of platform-specific font resource definitions in favor of direct font registration and usage.

**Font registration and usage improvements:**

* Registered FontAwesome fonts (`FontAwesomeBrands.otf`, `FontAwesomeRegular.otf`, `FontAwesomeSolid.otf`) directly with aliases (`FaBrandsFont`, `FaRegularFont`, `FaSolidFont`) in `MauiProgram.cs`, removing the need for platform-specific logic.
* Removed platform-specific `OnPlatform` font family definitions from `App.xaml`, and updated all usages of `FontFamily` in `FontImage` and `Label` controls to use the new direct font aliases. [[1]](diffhunk://#diff-418f037fe6b9a871a4727b6f037a98816a6197981c52f77ff568d31794226e86L14-R20) [[2]](diffhunk://#diff-491a541f467114cc4ad7fa7a5433f548d0d90e24f605b66d997c25c43bf1d461L32-R32)

These changes make font management simpler and reduce platform-specific complexity in the XAML files.